### PR TITLE
Makefile refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.vi
 *~
 *.sass-cache
+.stamp-*
 
 # OS or Editor folders
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,105 +1,148 @@
-BOOTSTRAP = ./docs/assets/css/bootstrap.css
-BOOTSTRAP_LESS = ./less/bootstrap.less
-BOOTSTRAP_RESPONSIVE = ./docs/assets/css/bootstrap-responsive.css
-BOOTSTRAP_RESPONSIVE_LESS = ./less/responsive.less
-DATE=$(shell date +%I:%M%p)
-CHECK=\033[32m✔\033[39m
-HR=\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#\#
+CHECK := \033[32m✔\033[39m
 
+# If make is run like `make V=1', then commands starting with $(AT)
+# will be echoed.
+V := 0
+AT_0 := @
+AT_1 :=
+AT := $(AT_$(V))
 
+all: bootstrap
+	@echo "Thanks for using Bootstrap,"
+	@echo "<3 @mdo and @fat"
 #
 # BUILD DOCS
 #
 
-build:
-	@echo "\n${HR}"
-	@echo "Building Bootstrap..."
-	@echo "${HR}\n"
-	@jshint js/*.js --config js/.jshintrc
-	@jshint js/tests/unit/*.js --config js/.jshintrc
-	@echo "Running JSHint on javascript...             ${CHECK} Done"
-	@recess --compile ${BOOTSTRAP_LESS} > ${BOOTSTRAP}
-	@recess --compile ${BOOTSTRAP_RESPONSIVE_LESS} > ${BOOTSTRAP_RESPONSIVE}
-	@echo "Compiling LESS with Recess...               ${CHECK} Done"
-	@node docs/build
-	@cp img/* docs/assets/img/
-	@cp js/*.js docs/assets/js/
-	@cp js/tests/vendor/jquery.js docs/assets/js/
+docs: .stamp-docs
+.stamp-docs: .stamp-bootstrap
+	$(AT)node docs/build
+	$(AT)cp img/* docs/assets/img/
+	$(AT)cp js/*.js docs/assets/js/
+	$(AT)cp js/tests/vendor/jquery.js docs/assets/js/
 	@echo "Compiling documentation...                  ${CHECK} Done"
-	@cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js js/bootstrap-affix.js > docs/assets/js/bootstrap.js
-	@uglifyjs -nc docs/assets/js/bootstrap.js > docs/assets/js/bootstrap.min.tmp.js
-	@echo "/**\n* Bootstrap.js v2.2.1 by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > docs/assets/js/copyright.js
-	@cat docs/assets/js/copyright.js docs/assets/js/bootstrap.min.tmp.js > docs/assets/js/bootstrap.min.js
-	@rm docs/assets/js/copyright.js docs/assets/js/bootstrap.min.tmp.js
-	@echo "Compiling and minifying javascript...       ${CHECK} Done"
-	@echo "\n${HR}"
-	@echo "Bootstrap successfully built at ${DATE}."
-	@echo "${HR}\n"
-	@echo "Thanks for using Bootstrap,"
-	@echo "<3 @mdo and @fat\n"
+	@touch $@
 
 #
 # RUN JSHINT & QUNIT TESTS IN PHANTOMJS
 #
 
 test:
-	jshint js/*.js --config js/.jshintrc
-	jshint js/tests/unit/*.js --config js/.jshintrc
-	node js/tests/server.js &
-	phantomjs js/tests/phantom.js "http://localhost:3000/js/tests"
-	kill -9 `cat js/tests/pid.txt`
-	rm js/tests/pid.txt
+	$(AT)jshint js/*.js --config js/.jshintrc
+	$(AT)jshint js/tests/unit/*.js --config js/.jshintrc
+	$(AT)node js/tests/server.js &
+	$(AT)phantomjs js/tests/phantom.js "http://localhost:3000/js/tests"
+	$(AT)kill -9 `cat js/tests/pid.txt`
+	$(AT)rm js/tests/pid.txt
+	@echo "Running JSHint on javascript...             $(CHECK) Done"
 
 #
 # CLEANS THE ROOT DIRECTORY OF PRIOR BUILDS
 #
 
 clean:
-	rm -r bootstrap
+	rm -f .stamp-*
+	rm -rf bootstrap
+
+#
+# JS
+#
+
+JS_DIR := bootstrap/js
+
+# List of _GENERATED_ js files.
+JS := $(JS_DIR)/bootstrap.js $(JS_DIR)/bootstrap.min.js
+
+# List of .js files that go into bootstrap.js
+JS_SRC := \
+	js/bootstrap-transition.js \
+	js/bootstrap-alert.js \
+	js/bootstrap-button.js \
+	js/bootstrap-carousel.js \
+	js/bootstrap-collapse.js \
+	js/bootstrap-dropdown.js \
+	js/bootstrap-modal.js \
+	js/bootstrap-tooltip.js \
+	js/bootstrap-popover.js \
+	js/bootstrap-scrollspy.js \
+	js/bootstrap-tab.js \
+	js/bootstrap-typeahead.js \
+	js/bootstrap-affix.js
+
+JS_COPYRIGHT := /*!\n\
+ * Bootstrap.js by @fat & @mdo\n\
+ * Copyright 2012 Twitter, Inc.\n\
+ * http://www.apache.org/licenses/LICENSE-2.0.txt\n\
+ */
+
+js: .stamp-js
+.stamp-js: $(JS)
+	@echo "Compiling and minifying javascript...       ${CHECK} Done"
+	@touch $@
+$(JS_DIR)/bootstrap.js: .stamp-mkdir $(JS_SRC)
+	$(AT)cat $(JS_SRC) > $@
+
+$(JS_DIR)/bootstrap.min.js: $(JS_DIR)/bootstrap.js
+	$(AT)echo '$(JS_COPYRIGHT)' > $@
+	$(AT)uglifyjs -nc $< >> $@
+
+#
+# CSS
+#
+
+CSS_DIR := bootstrap/css
+# List of _GENERATED_ CSS files.
+CSS := \
+	$(CSS_DIR)/bootstrap.css \
+	$(CSS_DIR)/bootstrap.min.css \
+	$(CSS_DIR)/bootstrap-responsive.css \
+	$(CSS_DIR)/bootstrap-responsive.min.css
+RECESS_COMPILE = $(AT)recess --compile $< > $@
+RECESS_COMPRESS = $(AT)recess --compress $< > $@
+
+BOOTSTRAP := ./docs/assets/css/bootstrap.css
+BOOTSTRAP_RESPONSIVE := ./docs/assets/css/bootstrap-responsive.css
+BOOTSTRAP_LESS := less/bootstrap.less
+BOOTSTRAP_RESPONSIVE_LESS := less/responsive.less
+
+css: .stamp-css
+.stamp-css: $(CSS)
+	@echo "Compiling LESS with Recess...               $(CHECK) Done"
+$(CSS_DIR)/bootstrap.css: \
+  $(BOOTSTRAP_LESS) .stamp-mkdir less/*.less; $(RECESS_COMPILE)
+$(CSS_DIR)/bootstrap.min.css: \
+  $(BOOTSTRAP_LESS) .stamp-mkdir less/*.less; $(RECESS_COMPRESS)
+$(CSS_DIR)/bootstrap-responsive.css: \
+  $(BOOTSTRAP_RESPONSIVE_LESS) .stamp-mkdir less/*.less; $(RECESS_COMPILE)
+$(CSS_DIR)/bootstrap-responsive.min.css: \
+  $(BOOTSTRAP_RESPONSIVE_LESS) .stamp-mkdir less/*.less; $(RECESS_COMPRESS)
+
+#
+# IMAGES
+#
+
+IMG_DIR := bootstrap/img
+
+.stamp-img: .stamp-mkdir img/*
+	$(AT)cp img/* $(IMG_DIR)
+	@touch $@
+
+img: .stamp-img
+
+# Ensure necessary directories are created.
+.stamp-mkdir:
+	$(AT)mkdir -p $(CSS_DIR) $(IMG_DIR) $(JS_DIR)
+	@touch $@
 
 #
 # BUILD SIMPLE BOOTSTRAP DIRECTORY
 # recess & uglifyjs are required
 #
 
-bootstrap: bootstrap-img bootstrap-css bootstrap-js
-
-#
-# JS
-#
-
-bootstrap-js: bootstrap/js/*.js
-
-bootstrap/js/*.js: js/*.js
-	mkdir -p bootstrap/js
-	cat js/bootstrap-transition.js js/bootstrap-alert.js js/bootstrap-button.js js/bootstrap-carousel.js js/bootstrap-collapse.js js/bootstrap-dropdown.js js/bootstrap-modal.js js/bootstrap-tooltip.js js/bootstrap-popover.js js/bootstrap-scrollspy.js js/bootstrap-tab.js js/bootstrap-typeahead.js js/bootstrap-affix.js > bootstrap/js/bootstrap.js
-	uglifyjs -nc bootstrap/js/bootstrap.js > bootstrap/js/bootstrap.min.tmp.js
-	echo "/*!\n* Bootstrap.js by @fat & @mdo\n* Copyright 2012 Twitter, Inc.\n* http://www.apache.org/licenses/LICENSE-2.0.txt\n*/" > bootstrap/js/copyright.js
-	cat bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js > bootstrap/js/bootstrap.min.js
-	rm bootstrap/js/copyright.js bootstrap/js/bootstrap.min.tmp.js
-
-#
-# CSS
-#
-
-bootstrap-css: bootstrap/css/*.css
-
-bootstrap/css/*.css: less/*.less
-	mkdir -p bootstrap/css
-	recess --compile ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.css
-	recess --compress ${BOOTSTRAP_LESS} > bootstrap/css/bootstrap.min.css
-	recess --compile ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.css
-	recess --compress ${BOOTSTRAP_RESPONSIVE_LESS} > bootstrap/css/bootstrap-responsive.min.css
-
-#
-# IMAGES
-#
-
-bootstrap-img: bootstrap/img/*
-
-bootstrap/img/*: img/*
-	mkdir -p bootstrap/img
-	cp img/* bootstrap/img/
+bootstrap: .stamp-bootstrap
+.stamp-bootstrap: .stamp-css .stamp-img .stamp-js
+	@echo "Bootstrap successfully built at `date +%I:%M%p`."
+	@touch $@
 
 #
 # MAKE FOR GH-PAGES 4 FAT & MDO ONLY (O_O  )
@@ -121,5 +164,4 @@ watch:
 	echo "Watching less files..."; \
 	watchr -e "watch('less/.*\.less') { system 'make' }"
 
-
-.PHONY: docs watch gh-pages bootstrap-img bootstrap-css bootstrap-js
+.PHONY: all bootstrap clean css docs gh-pages img js test watch


### PR DESCRIPTION
As promised on HN, here's the pull request. I'm sending it to you first since the Makefile project's your baby and you can try and push it upstream if you think it's good. (Also, I don't actually use bootstrap, so I need someone who does to make sure I haven't broken anything.)

Most of the added lines are because I've explicitly listed the js files instead of relying on wildcards.

The GNUisms have been removed (the use of $(shell ...)), so it should work on most make implementations.
The docs directory recycles the uglified js from the bootstrap dir, removing redundant work.
The status messages with the check marks are printed out as the build progresses.
The build is now significantly faster under parallel make (make -j)
It doesn't use temporary files when making the uglified js file.
Also, you can see all the interesting commands by running make V=1.

Let me know if there are any problems. If you want to blog about it, that's cool too.
